### PR TITLE
feat(build): produce fully self-contained JS bundle with Vue and styles inlined

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Greeter Component Demo</title>
-  <link rel="stylesheet" href="/dist/dashtomer-greeter-component-tht.css" />
   <style>
     body { font-family: sans-serif; margin: 2rem; }
     #demo-container { margin-top: 2rem; }
@@ -33,7 +32,6 @@
       <div id="demo-container-custom" style="margin-top:1rem;"></div>
     </div>
   </div>
-  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
   <script src="/dist/greeter.iife.js"></script>
   <script>
     // Default style demo

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "jsdom": "^26.1.0",
         "typescript": "~5.7.2",
         "vite": "^6.3.1",
+        "vite-plugin-css-injected-by-js": "^3.5.2",
         "vitest": "^3.1.1",
         "vue-tsc": "^2.2.8"
       }
@@ -2620,6 +2621,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-plugin-css-injected-by-js": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-3.5.2.tgz",
+      "integrity": "sha512-2MpU/Y+SCZyWUB6ua3HbJCrgnF0KACAsmzOQt1UvRVJCGF6S8xdA3ZUhWcWdM9ivG4I5az8PnQmwwrkC2CAQrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": ">2.0.0-0"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "jsdom": "^26.1.0",
     "typescript": "~5.7.2",
     "vite": "^6.3.1",
+    "vite-plugin-css-injected-by-js": "^3.5.2",
     "vitest": "^3.1.1",
     "vue-tsc": "^2.2.8"
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), cssInjectedByJsPlugin()],
+  define: {
+    'process.env.NODE_ENV': '"production"',
+    'process.env': '{}',
+    'process': '{}'
+  },
   build: {
     lib: {
       entry: 'src/init.ts',
@@ -12,10 +18,10 @@ export default defineConfig({
       fileName: (format) => `greeter.${format}.js`
     },
     rollupOptions: {
-      external: ['vue'],
+      // No externals; bundle everything for self-contained output
       output: {
         globals: {
-          vue: 'Vue'
+          // No need for globals since Vue is bundled
         }
       }
     }


### PR DESCRIPTION
- Updated Vite config to bundle Vue and inject component styles into the JS output using vite-plugin-css-injected-by-js
- Removed all external dependencies (no external Vue or CSS required)
- Adjusted demo/index.html to remove CDN Vue and CSS references, testing the self-contained bundle via <script src="dist/greeter.iife.js"></script>
- Ensured Greeter global is exposed and init() works as in the requirements usage example
- Fixed "process is not defined" error by defining process.env.NODE_ENV for browser builds

BREAKING CHANGE: Consumers now only need to include the single JS file; external Vue and CSS are no longer required.